### PR TITLE
corretto il pattern per match dialplan route points e wave lines

### DIFF
--- a/module/Contatta.class.php
+++ b/module/Contatta.class.php
@@ -120,7 +120,7 @@ class Contatta extends \FreePBX_Helpers implements \BMO
 
             $context = 'webcall';
             $exten = '_89XXX';
-            $ext->add($context, $exten, '', new \ext_goto('contatta,81${EXTEN:-2},1'));
+            $ext->add($context, $exten, '', new \ext_goto('contatta,81${EXTEN:-3},1'));
 
             $context = 'macro-contatta';
             $exten = 's';

--- a/module/Contatta.class.php
+++ b/module/Contatta.class.php
@@ -89,7 +89,7 @@ class Contatta extends \FreePBX_Helpers implements \BMO
             $context = 'contatta';
 
             //Configurazione Route Point
-            $exten = '81XXX';
+            $exten = '_81XXX';
             $ext->add($context, $exten, '', new \ext_ringing());
             foreach (explode(',',$agiip) as $ip) {
                 $ext->add($context, $exten, '', new \ext_agi('agi://'.$ip));
@@ -97,7 +97,7 @@ class Contatta extends \FreePBX_Helpers implements \BMO
             $ext->add($context, $exten, '', new \ext_hangup());
 
             //Configurazione Line IVR
-            $exten = '82XXX';
+            $exten = '_82XXX';
             foreach (explode(',',$agiip) as $ip) {
                 $ext->add($context, $exten, '', new \ext_agi('agi://'.$ip));
             }

--- a/module/Contatta.class.php
+++ b/module/Contatta.class.php
@@ -103,7 +103,7 @@ class Contatta extends \FreePBX_Helpers implements \BMO
             }
 
             //Stanza di conference
-            $exten = '85000.';
+            $exten = '_85000.';
             $ext->add($context, $exten, '', new \ext_noop('conference'));
             $ext->add($context, $exten, '', new \ext_answer(''));
             $ext->add($context, $exten, '', new \ext_noop('amministratore exten: ${EXTEN}'));
@@ -119,7 +119,7 @@ class Contatta extends \FreePBX_Helpers implements \BMO
             $ext->add($context, $exten, '', new \ext_meetme('${EXTEN:0:-1}'));
 
             $context = 'webcall';
-            $exten = '_89XXX.';
+            $exten = '_89XXX';
             $ext->add($context, $exten, '', new \ext_goto('contatta,81${EXTEN:-2},1'));
 
             $context = 'macro-contatta';


### PR DESCRIPTION
se il numero chiamato era ad esempio 81000 non faceva il match con 81XXX, la regex corretta è _81XXX